### PR TITLE
Some #149 changes I believe are worth it

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -499,7 +499,6 @@ its easier to just keep the beam vertical.
 	climbers |= user
 
 	if(!do_after(user,(issmall(user) ? smalltime : bigtime) - stat_to_modifier(user.stats[STAT_DX])*10 / 1.75, src))
-
 		climbers -= user
 		return
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -498,7 +498,7 @@ its easier to just keep the beam vertical.
 	user.visible_message("<span class='warning'>\The [user] starts climbing onto \the [src]!</span>")
 	climbers |= user
 
-	if(!do_after(user,(issmall(user) ? smalltime : bigtime) - stat_to_modifier(user.stats[STAT_DX])*10 / 1.75, src))
+	if(!do_after(user,(issmall(user) ? 30 : 50) - stat_to_modifier(user.stats[STAT_DX])*10 / 1.75, src))
 		climbers -= user
 		return
 

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -23,9 +23,6 @@
 	if (istype(AM, /mob/living))
 		var/mob/living/M =	AM
 		M.slip("the [src.name]",3)
-			if(prob(1))
-			to_chat(M, span_notice("You slipped so hard that after you hit the floor you got gibbed!"))
-			M.gib()
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -321,9 +321,7 @@
 	usr.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
 	climbers |= user
 
-
 	if(!do_after(user,(issmall(user) ? 24: 30) - stat_to_modifier(user.stats[STAT_DX])*10 / 1.75, src))
-
 		climbers -= user
 		return
 

--- a/code/modules/mob/living/carbon/human/matt_combat.dm
+++ b/code/modules/mob/living/carbon/human/matt_combat.dm
@@ -71,7 +71,7 @@
 	var/getupchance = (!stunned && !weakened) || (rand(1,50) < stats[STAT_DX]/1.5)
 	if(resting && getupchance)//The incapacitated proc includes resting for whatever fucking stupid reason I hate SS13 code so fucking much.
 		visible_message("<span class='notice'>[usr] is trying to get up.</span>")
-		if(do_after(src, 20 -  stat_to_modifier(user.stats[STAT_DX])*10 / 3))
+		if(do_after(src, 20 -  stat_to_modifier(stats[STAT_DX])*10 / 3))
 			resting = 0
 			rest.icon_state = "rest0"
 		return

--- a/code/modules/mob/living/carbon/human/matt_combat.dm
+++ b/code/modules/mob/living/carbon/human/matt_combat.dm
@@ -71,7 +71,6 @@
 	var/getupchance = (!stunned && !weakened) || (rand(1,50) < stats[STAT_DX]/1.5)
 	if(resting && getupchance)//The incapacitated proc includes resting for whatever fucking stupid reason I hate SS13 code so fucking much.
 		visible_message("<span class='notice'>[usr] is trying to get up.</span>")
-
 		if(do_after(src, 20 -  stat_to_modifier(user.stats[STAT_DX])*10 / 3))
 			resting = 0
 			rest.icon_state = "rest0"


### PR DESCRIPTION
A few changes to the DX timer modifications, which in my opinion add balance. For example, subtracting the DX value out of the wait time in do after causes a huge gap between DX differences.
I believe my approach would be a bit more balanced as there someone with 20 DX climbs 3x faster than someone with 1 DX.

Here are some time stats for comparison:
Railing : 1 DX : 6.5s
Railing : 10 DX : 3.3s
Railing : 20 DX : 1s
Desk: 1 DX : 8.5s
Desk: 10 DX : 5s
Desk: 20 DX : 2.5s

Also rolling on the ground with 20 DX happens almost instantly, while with 1 DX takes a the normal amount.

I have also made it so you have a small chance based on your DX level to be able to get up while stunned or weakened, and made it so your DX affects your get up time.

Ignore the soap throw commit its there bc im retarded.